### PR TITLE
Add vless muilti client configuration support on same port

### DIFF
--- a/web/assets/js/model/xray.js
+++ b/web/assets/js/model/xray.js
@@ -1182,6 +1182,14 @@ Inbound.VLESSSettings = class extends Inbound.Settings {
         this.fallbacks = fallbacks;
     }
 
+    addVLESS() {
+        this.vlesses.push(new Inbound.VLESSSettings.VLESS());
+    }
+
+    delVLESS(index) {
+        this.vlesses.splice(index, 1);
+    }
+    
     addFallback() {
         this.fallbacks.push(new Inbound.VLESSSettings.Fallback());
     }

--- a/web/html/xui/form/protocol/vless.html
+++ b/web/html/xui/form/protocol/vless.html
@@ -1,13 +1,26 @@
 {{define "form/vless"}}
 <a-form layout="inline">
+    <a-form-item label="client">
+        <a-row>
+            <a-button type="primary" size="small" @click="inbound.settings.addVLESS()">
+                +
+            </a-button>
+        </a-row>
+    </a-form-item>
+</a-form>
+<a-form v-for="(vlessobj, index) in inbound.settings.vlesses" layout="inline">
     <a-form-item label="id">
-        <a-input v-model.trim="inbound.settings.vlesses[0].id"></a-input>
+        <a-input v-model.trim="vlessobj.id"></a-input>
     </a-form-item>
     <a-form-item v-if="inbound.xtls" label="flow">
-        <a-select v-model="inbound.settings.vlesses[0].flow" style="width: 150px">
+        <a-select v-model="vlessobj.flow" style="width: 150px">
             <a-select-option value="">无</a-select-option>
             <a-select-option v-for="key in FLOW_CONTROL" :value="key">[[ key ]]</a-select-option>
         </a-select>
+    </a-form-item>
+    <a-form-item  layout="inline">
+        <a-icon v-if="index != 0" type="delete" @click="() => inbound.settings.delVLESS(index)"
+            style="color: rgb(255, 77, 79);cursor: pointer;" />
     </a-form-item>
 </a-form>
 


### PR DESCRIPTION
增加了在同端口使用多个UUID的VLESS配置
对应配置文件

```  json
    {
      "listen": null,
      "port": 443,
      "protocol": "vless",
      "settings": {
        "clients": [
          {
            "id": "uuid1",
            "flow": "xtls-rprx-direct"
          },
          {
            "id": "uuid2",
            "flow": "xtls-rprx-direct"
          }
        ],
        "decryption": "none",
        "fallbacks": []
      }
```