### PR TITLE
bugfix: 修改getStatus请求间隔+ 通过时间戳取代版本号解决缓存问题 + 增加登录失效时自动重定向到登录页面

### DIFF
--- a/web/assets/js/util/utils.js
+++ b/web/assets/js/util/utils.js
@@ -10,6 +10,12 @@ class HttpUtil {
             Vue.prototype.$message.success(msg.msg);
         } else {
             Vue.prototype.$message.error(msg.msg);
+            if (msg.msg == '登录时效已过，请重新登录') {
+                setTimeout(()=> {
+                    Vue.prototype.$message.warning("即将开始重新登录！")
+                    setTimeout(()=> {window.location.reload()},3000)
+                },2000)
+            }
         }
     }
 

--- a/web/controller/util.go
+++ b/web/controller/util.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 	"x-ui/config"
 	"x-ui/logger"
 	"x-ui/web/entity"
@@ -82,7 +83,8 @@ func html(c *gin.Context, name string, title string, data gin.H) {
 
 func getContext(h gin.H) gin.H {
 	a := gin.H{
-		"cur_ver": config.GetVersion(),
+		"cur_ver":   config.GetVersion(),
+		"timeStamp": time.Now().Unix(),
 	}
 	if h != nil {
 		for key, value := range h {

--- a/web/html/common/js.html
+++ b/web/html/common/js.html
@@ -8,12 +8,13 @@
 <script src="{{ .base_path }}assets/qrcode/qrious.min.js"></script>
 <script src="{{ .base_path }}assets/clipboard/clipboard.min.js"></script>
 <script src="{{ .base_path }}assets/uri/URI.min.js"></script>
-<script src="{{ .base_path }}assets/js/axios-init.js?{{ .cur_ver }}"></script>
-<script src="{{ .base_path }}assets/js/util/common.js?{{ .cur_ver }}"></script>
-<script src="{{ .base_path }}assets/js/util/date-util.js?{{ .cur_ver }}"></script>
-<script src="{{ .base_path }}assets/js/util/utils.js?{{ .cur_ver }}"></script>
-<script src="{{ .base_path }}assets/js/model/xray.js?{{ .cur_ver }}"></script>
-<script src="{{ .base_path }}assets/js/model/models.js?{{ .cur_ver }}"></script>
+<!-- 这里通过插入时间戳，避免因为浏览器缓存原因无法读取到js文件修改的变化 -->
+<script src="{{ .base_path }}assets/js/axios-init.js?{{ .timeStamp }}"></script>
+<script src="{{ .base_path }}assets/js/util/common.js?{{ .timeStamp }}"></script>
+<script src="{{ .base_path }}assets/js/util/date-util.js?{{ .timeStamp }}"></script>
+<script src="{{ .base_path }}assets/js/util/utils.js?{{ .timeStamp }}"></script>
+<script src="{{ .base_path }}assets/js/model/xray.js?{{ .timeStamp }}"></script>
+<script src="{{ .base_path }}assets/js/model/models.js?{{ .timeStamp }}"></script>
 <script>
     const basePath = '{{ .base_path }}';
     axios.defaults.baseURL = basePath;

--- a/web/html/xui/index.html
+++ b/web/html/xui/index.html
@@ -324,7 +324,7 @@
                 } catch (e) {
                     console.error(e);
                 }
-                await PromiseUtil.sleep(2000);
+                await PromiseUtil.sleep(15000);
             }
         },
     });


### PR DESCRIPTION
1. 修改getStatus请求间隔，避免过于频繁的请求服务器
2. 通过时间戳取代版本号，解决浏览器缓存导致的js文件修改无法生效的问题
3. 增加登录状态检查功能： 一旦登录失效，自动重定向到登录页。