### PR TITLE
Restart x-ui service at boot time of OS

### DIFF
--- a/x-ui.service
+++ b/x-ui.service
@@ -5,6 +5,8 @@ Wants=network.target
 
 [Service]
 Type=simple
+Restart=always
+RestartSec=3
 WorkingDirectory=/usr/local/x-ui/
 ExecStart=/usr/local/x-ui/x-ui
 


### PR DESCRIPTION
At OS startup, restarting the service is mandatory since I have some experiences on not completely the service started!