### PR TITLE
change listen addr from "" to "0.0.0.0"

### DIFF
--- a/web/service/setting.go
+++ b/web/service/setting.go
@@ -22,7 +22,7 @@ var xrayTemplateConfig string
 
 var defaultValueMap = map[string]string{
 	"xrayTemplateConfig": xrayTemplateConfig,
-	"webListen":          "",
+	"webListen":          "0.0.0.0",
 	"webPort":            "54321",
 	"webCertFile":        "",
 	"webKeyFile":         "",


### PR DESCRIPTION
change listen addr from "" to "0.0.0.0", which was causing service binding on only IPV6 addr.

https://github.com/vaxilu/x-ui/blob/9c1be8c57a53953b47ee7c09a93554e73816f907/web/web.go#L355

中代码使用 net.Listen 函数在指定的 listen 地址和端口上创建了一个 TCP 监听器（listener）。listen 是一个字符串类型的参数，表示监听的地址，例如："0.0.0.0" 或者 "::"。strconv.Itoa(port) 则将整型的 port 参数转换为字符串。

根据这段代码，如果 listen 参数的值为 "::"，则表示监听 IPv6 的所有地址，而不监听 IPv4 的地址。这可能导致web服务只监听了 IPv6 的端口，而没有监听 IPv4 的端口。

要同时监听 IPv4 和 IPv6 的地址，需要将 listen 参数的值设置为 "0.0.0.0"，这表示监听所有可用的网络接口，包括 IPv4 和 IPv6。

https://github.com/vaxilu/x-ui/blob/9c1be8c57a53953b47ee7c09a93554e73816f907/web/service/setting.go#L25

从代码中可以看出。listen 取到的默认参数为空字符串，如果 listen 参数的值为空字符串或者为零值，例如 "" 或 nil，则 net.Listen 函数将只会监听 IPv6 的地址，而不会监听 IPv4 的地址。这是因为在 Go 中，如果 listen 参数的值为空，或者为零值，net.Listen 函数会将其视为 ::，即监听 IPv6 的所有地址。

为了同时监听 IPv4 和 IPv6 的地址，应该将 listen 参数的值设置为 "0.0.0.0"，而不是空字符串或零值。