### PR TITLE
更新Dockerfile中的debian版本从11-slim到12.0-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . .
 RUN go build main.go
 
 
-FROM debian:11-slim
+FROM debian:12.0-slim
 RUN apt-get update && apt-get install -y --no-install-recommends -y ca-certificates \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 WORKDIR /root


### PR DESCRIPTION
更新Dockerfile中的debian版本从11-slim到12.0-slim，以适应新版本应用导致的GLIBC版本找不到的问题。